### PR TITLE
Test PR workflow: should pick up regressions built from develop and avoid rebuilding

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -110,5 +110,5 @@ runs:
       echo "::endgroup::"
 
       begin_group "Install python dependencies"
-      pip install pytest lxml
+      pip install pytest lxml tzdata
       echo "::endgroup::"

--- a/.github/workflows/clean_cache.yml
+++ b/.github/workflows/clean_cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup github runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -46,8 +46,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 // C++ Headers
-#include <math.h>
-
 #include <cmath>
 
 // ObjexxFCL Headers


### PR DESCRIPTION
Dumb (but still very valid) change to see PR testing. See expectations below

* baseline regression tests should be found on cache, so baseline shouldn't be rebuild at all
* ccache cache should be found,  branchbuild should be quick (< 1min)
* regresssion testing should work!

